### PR TITLE
[18.0][IMP] repair_service: Extensibility on _create_repair_sale_order_line

### DIFF
--- a/repair_service/README.rst
+++ b/repair_service/README.rst
@@ -81,11 +81,11 @@ Authors
 Contributors
 ------------
 
-- `ForgeFlow <https://forgeflow.com>`__:
+-  `ForgeFlow <https://forgeflow.com>`__:
 
-     - Andreu Orensanz <andreu.orensanz@forgeflow.com>
+      -  Andreu Orensanz <andreu.orensanz@forgeflow.com>
 
-- ``Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>``\ \_
+-  ``Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>``\ \_
 
 Maintainers
 -----------

--- a/repair_service/models/repair_service.py
+++ b/repair_service/models/repair_service.py
@@ -45,6 +45,17 @@ class RepairService(models.Model):
         for service in self:
             service.product_uom = service.product_id.uom_id
 
+    def _prepare_sale_order_line_vals(self, product_qty):
+        self.ensure_one()
+        return {
+            "order_id": self.repair_id.sale_order_id.id,
+            "product_id": self.product_id.id,
+            "product_uom_qty": product_qty,
+            "price_unit": (
+                0.0 if self.repair_id.under_warranty else self.product_id.lst_price
+            ),
+        }
+
     def _create_repair_sale_order_line(self):
         if not self:
             return
@@ -57,15 +68,6 @@ class RepairService(models.Model):
                 if service.repair_id.state != "done"
                 else service.product_uom_qty
             )
-            so_line_vals.append(
-                {
-                    "order_id": service.repair_id.sale_order_id.id,
-                    "product_id": service.product_id.id,
-                    "product_uom_qty": product_qty,
-                }
-            )
-            if service.repair_id.under_warranty:
-                so_line_vals[-1]["price_unit"] = 0.0
-            elif service.product_id.lst_price:
-                so_line_vals[-1]["price_unit"] = service.product_id.lst_price
+            vals = service._prepare_sale_order_line_vals(product_qty)
+            so_line_vals.append(vals)
         self.env["sale.order.line"].create(so_line_vals)


### PR DESCRIPTION
Just allow other modules to influence or add new info to the lines created